### PR TITLE
Refactor with rakefile

### DIFF
--- a/lib/night_writer.rb
+++ b/lib/night_writer.rb
@@ -77,7 +77,7 @@ class NightWriter
   #==== night_writer_test: test_it_can_modify_the_input_file & processable_test: test_it_can_write_to_a_file
   def translate
     text = read_file(@message)
-    modified = text.gsub(/[" "]/, " modified text ")
+    modified = text.gsub(/[ ]/, " modified text ")
     write_file(@output, modified)
   end
 end

--- a/lib/processable.rb
+++ b/lib/processable.rb
@@ -8,7 +8,6 @@ module Processable
   end
 
   def write_file(output_file, modified_text)
-    first_read = File.new(output_file, "w")
     File.open(output_file, "w") { |f| f.write "#{modified_text}".chomp }
     second_read = File.open(output_file, "r")
     puts "Created #{output_file} containing #{second_read.read.length} characters"

--- a/test/night_writer_test.rb
+++ b/test/night_writer_test.rb
@@ -65,14 +65,14 @@ class NightWriterTest < Minitest::Test
   end
 
   def test_translates_a_sentence_back_to_english_from_translated_braille_text
-    skip
+    # skip
     nightwriter = NightWriter.new("data/hello_braille.txt", "data/braille_to_english.txt")
 
     assert_equal "hello world", nightwriter.translate_to_english
   end
 
   def test_moves_to_new_lines_when_braille_translation_over_80_spaces
-    skip
+    # skip
     nightwriter = NightWriter.new("data/eighty_plus.txt", "data/eighty_plus_braille.txt")
 
     expected = "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.\n................................................................................\n................................................................................\n0.\n..\n..\n"

--- a/test/night_writer_test.rb
+++ b/test/night_writer_test.rb
@@ -25,8 +25,8 @@ class NightWriterTest < Minitest::Test
     nightwriter.translate
     nightwriter1.translate
 
-    assert_equal true, File.exists?("data/custom_name.txt")
-    assert_equal true, File.exists?("data/translated.txt")
+    assert_equal true, File.exist?("data/custom_name.txt")
+    assert_equal true, File.exist?("data/translated.txt")
   end
 
   def test_can_lookup_a_letter_and_create_an_charted_array


### PR DESCRIPTION
Corrected test errors and warnings that appeared after running the rake file.
  - Remove unused line from write_file method in module processable. Correct File.exists? to File.exist? in test_it_can_write_a_new_file_using_given_output_file_name
  - Correct <character class has duplicated range rake warning for test helper method translate in night_writer.rb